### PR TITLE
Travis: Remove python (No needed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ compiler:
   - clang
 #Disable gcc build for the moment...
 #  - gcc
-python:
- - "3.4" 
 before_install:
   - $CC --version
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
and it is now valided by http://lint.travis-ci.org/

(Hooray, your .travis.yml seems to be solid!)