### PR TITLE
nghttpx: set the supplementary group access list

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -257,7 +257,7 @@ std::unique_ptr<AcceptHandler> create_acceptor(ConnectionHandler *handler,
 namespace {
 void drop_privileges() {
   if (getuid() == 0 && get_config()->uid != 0) {
-    if (initgroups(get_config()->user.get()) != 0) {
+    if (initgroups(get_config()->user.get(), get_config()->gid) != 0) {
       auto error = errno;
       LOG(FATAL) << "Could not change supplementary groups: " << strerror(error);
       exit(EXIT_FAILURE);

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -756,6 +756,7 @@ int parse_config(const char *opt, const char *optarg) {
                  << strerror(errno);
       return -1;
     }
+    mod_config()->user = strcopy(pwd->pw_name);
     mod_config()->uid = pwd->pw_uid;
     mod_config()->gid = pwd->pw_gid;
 

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -268,6 +268,7 @@ struct Config {
   int syslog_facility;
   int backlog;
   int argc;
+  std::unique_ptr<char[]> user;
   uid_t uid;
   gid_t gid;
   pid_t pid;


### PR DESCRIPTION
When dropping privileges use [`initgroups(3)`](http://linux.die.net/man/3/initgroups) to set the supplementary group list of the selected user.
This allows to use the `ssl-cert` group on Ubuntu for example