### PR TITLE
Adding address option to select the address to bind to

### DIFF
--- a/src/HttpServer.cc
+++ b/src/HttpServer.cc
@@ -1536,7 +1536,7 @@ int start_listen(struct ev_loop *loop, Sessions *sessions,
       new ListenEventHandler(sessions, fd, acceptor);
 
       if (config->verbose) {
-        std::string s = util::numeric_name(rp);
+        std::string s = util::numeric_name(rp->ai_addr, rp->ai_addrlen);
         std::cout << (rp->ai_family == AF_INET ? "IPv4" : "IPv6") << ": listen "
                   << s << ":" << config->port << std::endl;
       }

--- a/src/HttpServer.cc
+++ b/src/HttpServer.cc
@@ -1536,8 +1536,7 @@ int start_listen(struct ev_loop *loop, Sessions *sessions,
       new ListenEventHandler(sessions, fd, acceptor);
 
       if (config->verbose) {
-        char s[INET6_ADDRSTRLEN];
-        get_ip_str((struct sockaddr *)rp->ai_addr, s, sizeof s);
+        std::string s = util::numeric_name(rp);
         std::cout << (rp->ai_family == AF_INET ? "IPv4" : "IPv6") << ": listen "
                   << s << ":" << config->port << std::endl;
       }

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -55,6 +55,7 @@ struct Config {
   std::string private_key_file;
   std::string cert_file;
   std::string dh_param_file;
+  std::string address;
   ev_tstamp stream_read_timeout;
   ev_tstamp stream_write_timeout;
   nghttp2_option *session_option;

--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -674,13 +674,13 @@ int HttpClient::noop() { return 0; }
 void HttpClient::on_connect_fail() {
   if (state == STATE_IDLE) {
     std::cerr << "[ERROR] Could not connect to the address "
-              << util::numeric_name(cur_addr) << std::endl;
+              << util::numeric_name(cur_addr->ai_addr, cur_addr->ai_addrlen) << std::endl;
   }
   auto cur_state = state;
   disconnect();
   if (cur_state == STATE_IDLE) {
     if (initiate_connection() == 0) {
-      std::cerr << "Trying next address " << util::numeric_name(cur_addr)
+      std::cerr << "Trying next address " << util::numeric_name(cur_addr->ai_addr, cur_addr->ai_addrlen)
                 << std::endl;
     }
   }

--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -107,20 +107,6 @@ std::string strip_fragment(const char *raw_uri) {
 }
 } // namespace
 
-namespace {
-// Returns numeric address string of |addr|.  If getnameinfo() is
-// failed, "unknown" is returned.
-std::string numeric_name(addrinfo *addr) {
-  char host[NI_MAXHOST];
-  auto rv = getnameinfo(addr->ai_addr, addr->ai_addrlen, host, sizeof(host),
-                        nullptr, 0, NI_NUMERICHOST);
-  if (rv != 0) {
-    return "unknown";
-  }
-  return host;
-}
-} // namespace
-
 Request::Request(const std::string &uri, const http_parser_url &u,
                  const nghttp2_data_provider *data_prd, int64_t data_length,
                  const nghttp2_priority_spec &pri_spec,
@@ -688,13 +674,13 @@ int HttpClient::noop() { return 0; }
 void HttpClient::on_connect_fail() {
   if (state == STATE_IDLE) {
     std::cerr << "[ERROR] Could not connect to the address "
-              << numeric_name(cur_addr) << std::endl;
+              << util::numeric_name(cur_addr) << std::endl;
   }
   auto cur_state = state;
   disconnect();
   if (cur_state == STATE_IDLE) {
     if (initiate_connection() == 0) {
-      std::cerr << "Trying next address " << numeric_name(cur_addr)
+      std::cerr << "Trying next address " << util::numeric_name(cur_addr)
                 << std::endl;
     }
   }

--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -154,27 +154,26 @@ int main(int argc, char **argv) {
   while (1) {
     static int flag = 0;
     static option long_options[] = {
-      { "address", required_argument, nullptr, 'a' },
-      { "daemon", no_argument, nullptr, 'D' },
-      { "htdocs", required_argument, nullptr, 'd' },
-      { "help", no_argument, nullptr, 'h' },
-      { "verbose", no_argument, nullptr, 'v' },
-      { "verify-client", no_argument, nullptr, 'V' },
-      { "header-table-size", required_argument, nullptr, 'c' },
-      { "push", required_argument, nullptr, 'p' },
-      { "padding", required_argument, nullptr, 'b' },
-      { "workers", required_argument, nullptr, 'n' },
-      { "error-gzip", no_argument, nullptr, 'e' },
-      { "no-tls", no_argument, &flag, 1 },
-      { "color", no_argument, &flag, 2 },
-      { "version", no_argument, &flag, 3 },
-      { "dh-param-file", required_argument, &flag, 4 },
-      { "early-response", no_argument, &flag, 5 },
-      { nullptr, 0, nullptr, 0 }
-    };
+        {"address", required_argument, nullptr, 'a'},
+        {"daemon", no_argument, nullptr, 'D'},
+        {"htdocs", required_argument, nullptr, 'd'},
+        {"help", no_argument, nullptr, 'h'},
+        {"verbose", no_argument, nullptr, 'v'},
+        {"verify-client", no_argument, nullptr, 'V'},
+        {"header-table-size", required_argument, nullptr, 'c'},
+        {"push", required_argument, nullptr, 'p'},
+        {"padding", required_argument, nullptr, 'b'},
+        {"workers", required_argument, nullptr, 'n'},
+        {"error-gzip", no_argument, nullptr, 'e'},
+        {"no-tls", no_argument, &flag, 1},
+        {"color", no_argument, &flag, 2},
+        {"version", no_argument, &flag, 3},
+        {"dh-param-file", required_argument, &flag, 4},
+        {"early-response", no_argument, &flag, 5},
+        {nullptr, 0, nullptr, 0}};
     int option_index = 0;
-    int c = getopt_long(argc, argv, "DVb:c:d:ehn:p:va:", long_options,
-                        &option_index);
+    int c = 
+        getopt_long(argc, argv, "DVb:c:d:ehn:p:va:", long_options, &option_index);
     char *end;
     if (c == -1) {
       break;

--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
         {"early-response", no_argument, &flag, 5},
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
-    int c = 
+    int c =
         getopt_long(argc, argv, "DVb:c:d:ehn:p:va:", long_options, &option_index);
     char *end;
     if (c == -1) {

--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -97,6 +97,9 @@ void print_help(std::ostream &out) {
   <CERT>      Set  path  to  server's  certificate.   Required  unless
               --no-tls is specified.
 Options:
+  -a  --address
+              The address to bind to.  If not specified the default IP
+              address determined by getaddrinfo is used.
   -D, --daemon
               Run in a background.  If -D is used, the current working
               directory is  changed to '/'.  Therefore  if this option
@@ -151,30 +154,35 @@ int main(int argc, char **argv) {
   while (1) {
     static int flag = 0;
     static option long_options[] = {
-        {"daemon", no_argument, nullptr, 'D'},
-        {"htdocs", required_argument, nullptr, 'd'},
-        {"help", no_argument, nullptr, 'h'},
-        {"verbose", no_argument, nullptr, 'v'},
-        {"verify-client", no_argument, nullptr, 'V'},
-        {"header-table-size", required_argument, nullptr, 'c'},
-        {"push", required_argument, nullptr, 'p'},
-        {"padding", required_argument, nullptr, 'b'},
-        {"workers", required_argument, nullptr, 'n'},
-        {"error-gzip", no_argument, nullptr, 'e'},
-        {"no-tls", no_argument, &flag, 1},
-        {"color", no_argument, &flag, 2},
-        {"version", no_argument, &flag, 3},
-        {"dh-param-file", required_argument, &flag, 4},
-        {"early-response", no_argument, &flag, 5},
-        {nullptr, 0, nullptr, 0}};
+      { "address", required_argument, nullptr, 'a' },
+      { "daemon", no_argument, nullptr, 'D' },
+      { "htdocs", required_argument, nullptr, 'd' },
+      { "help", no_argument, nullptr, 'h' },
+      { "verbose", no_argument, nullptr, 'v' },
+      { "verify-client", no_argument, nullptr, 'V' },
+      { "header-table-size", required_argument, nullptr, 'c' },
+      { "push", required_argument, nullptr, 'p' },
+      { "padding", required_argument, nullptr, 'b' },
+      { "workers", required_argument, nullptr, 'n' },
+      { "error-gzip", no_argument, nullptr, 'e' },
+      { "no-tls", no_argument, &flag, 1 },
+      { "color", no_argument, &flag, 2 },
+      { "version", no_argument, &flag, 3 },
+      { "dh-param-file", required_argument, &flag, 4 },
+      { "early-response", no_argument, &flag, 5 },
+      { nullptr, 0, nullptr, 0 }
+    };
     int option_index = 0;
-    int c =
-        getopt_long(argc, argv, "DVb:c:d:ehn:p:v", long_options, &option_index);
+    int c = getopt_long(argc, argv, "DVb:c:d:ehn:p:va:", long_options,
+                        &option_index);
     char *end;
     if (c == -1) {
       break;
     }
     switch (c) {
+    case 'a':
+      config.address = optarg;
+      break;
     case 'D':
       config.daemon = true;
       break;

--- a/src/util.cc
+++ b/src/util.cc
@@ -688,9 +688,9 @@ bool numeric_host(const char *hostname) {
 
 // Returns numeric address string of |addr|.  If getnameinfo() is
 // failed, "unknown" is returned.
-std::string numeric_name(addrinfo *addr) {
+std::string numeric_name(const struct sockaddr *sa, socklen_t salen) {
   char host[NI_MAXHOST];
-  auto rv = getnameinfo(addr->ai_addr, addr->ai_addrlen, host, sizeof(host),
+  auto rv = getnameinfo(sa, salen, host, sizeof(host),
                         nullptr, 0, NI_NUMERICHOST);
   if (rv != 0) {
     return "unknown";

--- a/src/util.cc
+++ b/src/util.cc
@@ -686,6 +686,18 @@ bool numeric_host(const char *hostname) {
   return true;
 }
 
+// Returns numeric address string of |addr|.  If getnameinfo() is
+// failed, "unknown" is returned.
+std::string numeric_name(addrinfo *addr) {
+  char host[NI_MAXHOST];
+  auto rv = getnameinfo(addr->ai_addr, addr->ai_addrlen, host, sizeof(host),
+                        nullptr, 0, NI_NUMERICHOST);
+  if (rv != 0) {
+    return "unknown";
+  }
+  return host;
+}
+
 int reopen_log_file(const char *path) {
 #if defined(__ANDROID__) || defined(ANDROID)
   int fd;

--- a/src/util.h
+++ b/src/util.h
@@ -418,7 +418,7 @@ void write_uri_field(std::ostream &o, const char *uri, const http_parser_url &u,
 
 bool numeric_host(const char *hostname);
 
-std::string numeric_name(addrinfo *addr);
+std::string numeric_name(const struct sockaddr *sa, socklen_t salen);
 
 // Opens |path| with O_APPEND enabled.  If file does not exist, it is
 // created first.  This function returns file descriptor referring the

--- a/src/util.h
+++ b/src/util.h
@@ -29,6 +29,7 @@
 
 #include <unistd.h>
 #include <getopt.h>
+#include <netdb.h>
 
 #include <cstring>
 #include <cassert>
@@ -416,6 +417,8 @@ void write_uri_field(std::ostream &o, const char *uri, const http_parser_url &u,
                      http_parser_url_fields field);
 
 bool numeric_host(const char *hostname);
+
+std::string numeric_name(addrinfo *addr);
 
 // Opens |path| with O_APPEND enabled.  If file does not exist, it is
 // created first.  This function returns file descriptor referring the


### PR DESCRIPTION
This change adds a `-a` parameter that can be used to select the IP address that the http server will bind to.  During testing I used this option to use multiple http servers on the same machine each with different addresses.  The parameter is optional and if not specified then the server binds to the default address returned from `getaddrinfo`.  This option is available in other http servers such as node's `http-server`.  I also added some additional logic to the print statement so that the address is printed along with the port.

Note I was having some trouble with getting clang-format to work correctly on Ubuntu so I had to edit the formatting manually.  I think it is pretty close to the style that you have setup but let me know if there are any formatting changes that need to be addressed.