### PR TITLE
replacing thread_local, which does not exist on OS X, with pthread_getsp...

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1884,15 +1884,15 @@ int main(int argc, char **argv) {
   }
 
   if (get_config()->uid != 0) {
-    if (log_config->accesslog_fd != -1 &&
-        fchown(log_config->accesslog_fd, get_config()->uid,
+    if (log_config()->accesslog_fd != -1 &&
+        fchown(log_config()->accesslog_fd, get_config()->uid,
                get_config()->gid) == -1) {
       auto error = errno;
       LOG(WARN) << "Changing owner of access log file failed: "
                 << strerror(error);
     }
-    if (log_config->errorlog_fd != -1 &&
-        fchown(log_config->errorlog_fd, get_config()->uid, get_config()->gid) ==
+    if (log_config()->errorlog_fd != -1 &&
+        fchown(log_config()->errorlog_fd, get_config()->uid, get_config()->gid) ==
             -1) {
       auto error = errno;
       LOG(WARN) << "Changing owner of error log file failed: "

--- a/src/shrpx_http_downstream_connection.cc
+++ b/src/shrpx_http_downstream_connection.cc
@@ -358,7 +358,7 @@ int HttpDownstreamConnection::push_request_headers() {
   if (LOG_ENABLED(INFO)) {
     const char *hdrp;
     std::string nhdrs;
-    if (log_config->errorlog_tty) {
+    if (log_config()->errorlog_tty) {
       nhdrs = http::colorizeHeaders(hdrs.c_str());
       hdrp = nhdrs.c_str();
     } else {

--- a/src/shrpx_https_upstream.cc
+++ b/src/shrpx_https_upstream.cc
@@ -808,7 +808,7 @@ int HttpsUpstream::on_downstream_abort_request(Downstream *downstream,
 void HttpsUpstream::log_response_headers(const std::string &hdrs) const {
   const char *hdrp;
   std::string nhdrs;
-  if (log_config->errorlog_tty) {
+  if (log_config()->errorlog_tty) {
     nhdrs = http::colorizeHeaders(hdrs.c_str());
     hdrp = nhdrs.c_str();
   } else {

--- a/src/shrpx_log.cc
+++ b/src/shrpx_log.cc
@@ -99,7 +99,7 @@ Log::~Log() {
     return;
   }
 
-  auto lgconf = log_config;
+  auto lgconf = log_config();
 
   if (!log_enabled(severity_) ||
       (lgconf->errorlog_fd == -1 && !get_config()->errorlog_syslog)) {
@@ -159,7 +159,7 @@ std::pair<OutputIterator, size_t> copy(const char *src, size_t avail,
 } // namespace
 
 void upstream_accesslog(const std::vector<LogFragment> &lfv, LogSpec *lgsp) {
-  auto lgconf = log_config;
+  auto lgconf = log_config();
 
   if (lgconf->accesslog_fd == -1 && !get_config()->accesslog_syslog) {
     return;
@@ -272,7 +272,7 @@ void upstream_accesslog(const std::vector<LogFragment> &lfv, LogSpec *lgsp) {
 int reopen_log_files() {
   int res = 0;
 
-  auto lgconf = log_config;
+  auto lgconf = log_config();
 
   if (lgconf->accesslog_fd != -1) {
     close(lgconf->accesslog_fd);

--- a/src/shrpx_log.h
+++ b/src/shrpx_log.h
@@ -97,8 +97,8 @@ private:
   static int severity_thres_;
 };
 
-#define TTY_HTTP_HD (log_config->errorlog_tty ? "\033[1;34m" : "")
-#define TTY_RST (log_config->errorlog_tty ? "\033[0m" : "")
+#define TTY_HTTP_HD (log_config()->errorlog_tty ? "\033[1;34m" : "")
+#define TTY_RST (log_config()->errorlog_tty ? "\033[0m" : "")
 
 enum LogFragmentType {
   SHRPX_LOGF_NONE,

--- a/src/shrpx_log_config.h
+++ b/src/shrpx_log_config.h
@@ -46,11 +46,7 @@ struct LogConfig {
 
 // We need LogConfig per thread to avoid data race around opening file
 // descriptor for log files.
-extern
-#ifndef NOTHREADS
-    thread_local
-#endif // NOTHREADS
-    LogConfig *log_config;
+extern LogConfig *log_config(void);
 
 } // namespace shrpx
 


### PR DESCRIPTION
A patch to enable threaded apps on OS X by replacing thread_local vars with a function that uses pthread_getspecific.