### PR TITLE
nghttp2.h: remove trailing comma last in enum

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -689,7 +689,7 @@ typedef enum {
    * trailer header fields with `nghttp2_submit_request()` or
    * `nghttp2_submit_response()`.
    */
-  NGHTTP2_DATA_FLAG_NO_END_STREAM = 0x02,
+  NGHTTP2_DATA_FLAG_NO_END_STREAM = 0x02
 } nghttp2_data_flag;
 
 /**


### PR DESCRIPTION
... since gcc -pedantic warns on it.
