### PR TITLE
README.rst: OpenSSL 1.0.2 has already been released

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ required:
 * libev >= 4.15
 * zlib >= 1.2.3
 
-ALPN support requires an unreleased version of OpenSSL >= 1.0.2.
+ALPN support requires OpenSSL >= 1.0.2 (released 22 January 2015).
 
 To enable the SPDY protocol in the application program ``nghttpx`` and
 ``h2load``, the following package is required:


### PR DESCRIPTION
OpenSSL 1.0.2 is already released. Avoid the confusing wording that
seems to suggest that a development version of OpenSSL 1.0.2 provides
ALPN support.