### PR TITLE
h2load_spdy_session errno include

### DIFF
--- a/src/h2load_spdy_session.cc
+++ b/src/h2load_spdy_session.cc
@@ -25,6 +25,7 @@
 #include "h2load_spdy_session.h"
 
 #include <cassert>
+#include <cerrno>
 
 #include "h2load.h"
 #include "util.h"


### PR DESCRIPTION
Compilation error around errno when building with Dockerfile.android