### PR TITLE
Add Upstart configuration file

### DIFF
--- a/contrib/nghttpx-upstart.conf
+++ b/contrib/nghttpx-upstart.conf
@@ -1,0 +1,8 @@
+# vim: ft=upstart:
+
+description "HTTP/2 reverse proxy"
+
+start on runlevel [2]
+stop on runlevel [016]
+
+exec /usr/bin/nghttpx


### PR DESCRIPTION
Upstart is used in Ubuntu 6.10 -> Ubuntu 14.10 as the default init daemon.

Starting with Ubuntu 15.04, Ubuntu switched to systemd.

Ubuntu Server LTS releases (12.04 and 14.04) are still using Upstart as their default init daemon.

This is the Upstart configuration file for those releases. :-)