### PR TITLE
rv is only used in an assert.

### DIFF
--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -1729,7 +1729,9 @@ static int hd_inflate_remove_bufs(nghttp2_hd_inflater *inflater, nghttp2_nv *nv,
 static int hd_inflate_remove_bufs_with_name(nghttp2_hd_inflater *inflater,
                                             nghttp2_nv *nv,
                                             nghttp2_hd_entry *ent_name) {
+#ifndef NDEBUG
   size_t rv;
+#endif
   size_t buflen;
   uint8_t *buf;
   nghttp2_mem *mem;
@@ -1747,8 +1749,11 @@ static int hd_inflate_remove_bufs_with_name(nghttp2_hd_inflater *inflater,
 
   /* Copy including terminal NULL */
   memcpy(buf, ent_name->nv.name, ent_name->nv.namelen + 1);
-  rv = nghttp2_bufs_remove_copy(&inflater->nvbufs,
-                                buf + ent_name->nv.namelen + 1);
+#ifndef NDEBUG
+  rv =
+#endif
+  nghttp2_bufs_remove_copy(&inflater->nvbufs,
+                           buf + ent_name->nv.namelen + 1);
   assert(ent_name->nv.namelen + 1 + rv == buflen);
 
   nghttp2_bufs_reset(&inflater->nvbufs);


### PR DESCRIPTION
The assert only evaluates to code if NDEBUG is undefined. Protect rv and its use accordingly

Issue reported by Joerg Mayer
https://code.wireshark.org/review/8260