### PR TITLE
Catch and log failure to set TCP_NODELAY

### DIFF
--- a/python/nghttp2.pyx
+++ b/python/nghttp2.pyx
@@ -1238,7 +1238,10 @@ if asyncio:
 
             self.transport = transport
             sock = self.transport.get_extra_info('socket')
-            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            try:
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            except OSError as e:
+                logging.info('failed to set tcp-nodelay: %s', str(e))
             ssl_ctx = self.transport.get_extra_info('sslcontext')
             if ssl_ctx:
                 protocol = sock.selected_npn_protocol()


### PR DESCRIPTION
Setting TCP_NODELAY may fail. Instead of failing the routine, log it and continue.
It seems, that setting TCP_NODELAY in python on Mac OS X is not necessarily supported.
