### PR TITLE
nghttpx: Add AES-256-CBC encryption for TLS session ticket

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -91,6 +91,7 @@ OPTIONS = [
     "header-field-buffer",
     "max-header-fields",
     "include",
+    "tls-ticket-cipher",
     "conf",
 ]
 

--- a/src/shrpx-unittest.cc
+++ b/src/shrpx-unittest.cc
@@ -122,6 +122,8 @@ int main(int argc, char *argv[]) {
                    shrpx::test_shrpx_config_parse_log_format) ||
       !CU_add_test(pSuite, "config_read_tls_ticket_key_file",
                    shrpx::test_shrpx_config_read_tls_ticket_key_file) ||
+      !CU_add_test(pSuite, "config_read_tls_ticket_key_file_aes_256",
+                   shrpx::test_shrpx_config_read_tls_ticket_key_file_aes_256) ||
       !CU_add_test(pSuite, "config_match_downstream_addr_group",
                    shrpx::test_shrpx_config_match_downstream_addr_group) ||
       !CU_add_test(pSuite, "util_streq", shrpx::test_util_streq) ||

--- a/src/shrpx_config_test.h
+++ b/src/shrpx_config_test.h
@@ -35,6 +35,7 @@ void test_shrpx_config_parse_config_str_list(void);
 void test_shrpx_config_parse_header(void);
 void test_shrpx_config_parse_log_format(void);
 void test_shrpx_config_read_tls_ticket_key_file(void);
+void test_shrpx_config_read_tls_ticket_key_file_aes_256(void);
 void test_shrpx_config_match_downstream_addr_group(void);
 
 } // namespace shrpx

--- a/src/util.h
+++ b/src/util.h
@@ -212,6 +212,10 @@ std::string quote_string(const std::string &target);
 
 std::string format_hex(const unsigned char *s, size_t len);
 
+template <size_t N> std::string format_hex(const unsigned char (&s)[N]) {
+  return format_hex(s, N);
+}
+
 std::string http_date(time_t t);
 
 // Returns given time |t| from epoch in Common Log format (e.g.,


### PR DESCRIPTION
This PR adds AES-256-CBC cipher to encrypt TLS session ticket.
For this purpose, we added --tls-ticket-cipher option.  The available values are aes-128-cbc (this is default), and aes-256-cbc.
Since we used the same file format with nginx and apache, we used 16 bytes key for HMAC SHA-256.
It seems this is not a big problem today, but we have not figured out the reason why 16 bytes are used.
So this PR attempts to fix this.  When --tls-ticket-key-file is not used, we now use 32 bytes for HMAC key,as suggested in RFC 5077.  When --tls-ticket-key-file is used, and aes-128-cbc is given in new --tls-ticket-cipher option, 16 bytes HMAC key is used for backward compatibility.  On the other hand, with file and aes-256-cbc in --tls-ticket-cipher, full 32 bytes HMAC key is used.