### PR TITLE
Fix rm: cannot remove ‘*.rst’: No such file or directory when "make c…

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -223,7 +223,7 @@ $(APIDOC): apidoc.stamp
 	fi
 
 clean-local:
-	-rm $(APIDOCS) > /dev/null 2>&1
+	-rm -f $(APIDOCS)
 	-rm -rf $(BUILDDIR)/*
 
 html-local: apiref.rst


### PR DESCRIPTION
  Fix rm: cannot remove ‘*.rst’: No such file or directory when "make clean"

When you don't generated documentation via make html

