### PR TITLE
Map /dev/stdout and /dev/stderr to their descriptors.

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1059,12 +1059,7 @@ void fill_default_config() {
   mod_config()->accesslog_file = nullptr;
   mod_config()->accesslog_syslog = false;
   mod_config()->accesslog_format = parse_log_format(DEFAULT_ACCESSLOG_FORMAT);
-#if defined(__ANDROID__) || defined(ANDROID)
-  // Android does not have /dev/stderr.  Use /proc/self/fd/2 instead.
-  mod_config()->errorlog_file = strcopy("/proc/self/fd/2");
-#else  // !__ANDROID__ && ANDROID
   mod_config()->errorlog_file = strcopy("/dev/stderr");
-#endif // !__ANDROID__ && ANDROID
   mod_config()->errorlog_syslog = false;
   mod_config()->conf_path = strcopy("/etc/nghttpx/nghttpx.conf");
   mod_config()->syslog_facility = LOG_DAEMON;

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -564,6 +564,9 @@ void exec_binary_signal_cb(struct ev_loop *loop, ev_signal *w, int revents) {
     }
   }
 
+  // restores original stderr
+  util::restore_original_fds();
+
   if (execve(argv[0], argv.get(), envp.get()) == -1) {
     auto error = errno;
     LOG(ERROR) << "execve failed: errno=" << error;
@@ -1762,6 +1765,9 @@ int main(int argc, char **argv) {
   Log::set_severity_level(NOTICE);
   create_config();
   fill_default_config();
+
+  // make copy of stderr
+  util::store_original_fds();
 
   // First open log files with default configuration, so that we can
   // log errors/warnings while reading configuration files.

--- a/src/util.cc
+++ b/src/util.cc
@@ -657,7 +657,21 @@ std::string numeric_name(const struct sockaddr *sa, socklen_t salen) {
   return host.data();
 }
 
-int reopen_log_file(const char *path) {
+
+void close_log_file(int &fd) {
+  if (fd != STDERR_FILENO && fd != STDOUT_FILENO && fd != -1) {
+    close(fd);
+  }
+  fd = -1;
+}
+
+int open_log_file(const char *path) {
+  if (strcmp(path, "/dev/stdout") == 0) {
+    return STDOUT_FILENO;
+  }
+  if (strcmp(path, "/dev/stderr") == 0) {
+    return STDERR_FILENO;
+  }
 #if defined(__ANDROID__) || defined(ANDROID)
   int fd;
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -666,27 +666,17 @@ void close_log_file(int &fd) {
 }
 
 int open_log_file(const char *path) {
-  if (strcmp(path, "/dev/stdout") == 0) {
+
+  if (strcmp(path, "/dev/stdout") == 0 ||
+      strcmp(path, "/proc/self/fd/1") == 0) {
     return STDOUT_FILENO;
   }
-  if (strcmp(path, "/dev/stderr") == 0) {
+
+  if (strcmp(path, "/dev/stderr") == 0 ||
+      strcmp(path, "/proc/self/fd/2") == 0) {
     return STDERR_FILENO;
   }
-#if defined(__ANDROID__) || defined(ANDROID)
-  int fd;
-
-  if (strcmp("/proc/self/fd/1", path) == 0 ||
-      strcmp("/proc/self/fd/2", path) == 0) {
-
-    // We will get permission denied error when O_APPEND is used for
-    // these paths.
-    fd =
-        open(path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP);
-  } else {
-    fd = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC,
-              S_IRUSR | S_IWUSR | S_IRGRP);
-  }
-#elif defined O_CLOEXEC
+#if defined O_CLOEXEC
 
   auto fd = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC,
                  S_IRUSR | S_IWUSR | S_IRGRP);

--- a/src/util.h
+++ b/src/util.h
@@ -516,6 +516,14 @@ bool numeric_host(const char *hostname);
 // failed, "unknown" is returned.
 std::string numeric_name(const struct sockaddr *sa, socklen_t salen);
 
+// Makes internal copy of stderr (and possibly stdout in the future),
+// which is then used as pointer to /dev/stderr or /proc/self/fd/2
+void store_original_fds();
+
+// Restores the original stderr that was stored with copy_original_fds
+// Used just before execv
+void restore_original_fds();
+
 // Closes |fd| which was returned by open_log_file (see below)
 // and sets it to -1. In the case that |fd| points to stdout or
 // stderr, or is -1, the descriptor is not closed (but still set to -1).

--- a/src/util.h
+++ b/src/util.h
@@ -516,10 +516,15 @@ bool numeric_host(const char *hostname);
 // failed, "unknown" is returned.
 std::string numeric_name(const struct sockaddr *sa, socklen_t salen);
 
+// Closes |fd| which was returned by open_log_file (see below)
+// and sets it to -1. In the case that |fd| points to stdout or
+// stderr, or is -1, the descriptor is not closed (but still set to -1).
+void close_log_file(int &fd);
+
 // Opens |path| with O_APPEND enabled.  If file does not exist, it is
 // created first.  This function returns file descriptor referring the
 // opened file if it succeeds, or -1.
-int reopen_log_file(const char *path);
+int open_log_file(const char *path);
 
 // Returns ASCII dump of |data| of length |len|.  Only ASCII printable
 // characters are preserved.  Other characters are replaced with ".".


### PR DESCRIPTION
This seems to do the trick for the issue #325.

It may also be used to simplify the Android-specific workarounds with /proc/self/df/2.