### PR TITLE
h2load allow -r < -n when -n is not specified 

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1115,6 +1115,7 @@ int main(int argc, char **argv) {
   OPENSSL_config(nullptr);
 
   std::string datafile;
+  bool nreqs_set_manually = false;
   while (1) {
     static int flag = 0;
     static option long_options[] = {
@@ -1144,6 +1145,7 @@ int main(int argc, char **argv) {
     switch (c) {
     case 'n':
       config.nreqs = strtoul(optarg, nullptr, 10);
+      nreqs_set_manually = true;
       break;
     case 'c':
       config.nclients = strtoul(optarg, nullptr, 10);
@@ -1322,7 +1324,7 @@ int main(int argc, char **argv) {
       exit(EXIT_FAILURE);
     }
 
-    if (config.rate > config.nreqs) {
+    if (nreqs_set_manually && config.rate > config.nreqs) {
       std::cerr << "-r, -n: the connection rate must be smaller than or equal "
                    "to the number of requests." << std::endl;
       exit(EXIT_FAILURE);
@@ -1333,6 +1335,13 @@ int main(int argc, char **argv) {
           << "-C, -t: the total number of connections must be greater than "
              "or equal "
           << "to the number of threads." << std::endl;
+      exit(EXIT_FAILURE);
+    }
+
+    if (config.nconns == 0 && !nreqs_set_manually) {
+      std::cerr
+          << "-r: the rate option must be used with either the -n option "
+             "or the -C option." << std::endl;
       exit(EXIT_FAILURE);
     }
   }


### PR DESCRIPTION
Continuing #324 as single commit. 