### PR TITLE
Add Timing-script and base URI support

### DIFF
--- a/src/h2load.h
+++ b/src/h2load.h
@@ -62,6 +62,7 @@ struct Worker;
 struct Config {
   std::vector<std::vector<nghttp2_nv>> nva;
   std::vector<std::vector<const char *>> nv;
+  std::vector<ev_tstamp> timings;
   nghttp2::Headers custom_headers;
   std::string scheme;
   std::string host;
@@ -91,11 +92,14 @@ struct Config {
   uint16_t port;
   uint16_t default_port;
   bool verbose;
+  bool timing_script;
+  std::string base_uri;
 
   Config();
   ~Config();
 
   bool is_rate_mode() const;
+  bool has_base_uri() const;
 };
 
 struct RequestStat {
@@ -208,6 +212,7 @@ struct Client {
   std::function<int(Client &)> readfn, writefn;
   Worker *worker;
   SSL *ssl;
+  ev_timer request_timeout_watcher;
   addrinfo *next_addr;
   size_t reqidx;
   ClientState state;


### PR DESCRIPTION
Hi Tatsuhurio,

This pull request adds two features to h2load:

1) A new timing script file to allow h2load to issue requests according to a script. A copy of the script is executed by all clients. The file format is tab-separated, field one defines the time to execute the request, measured from the start in milliseconds to microsecond resolution. Field two defines the URI. A new command-line parameter is added to h2load to define the use of this file. The number of requests is contrained to the length of the file, it doesn't seem logical to loop back to start of script.

Example file format
```
    100.0	https://localhost/index.html
    200.0	/style.css
    300	/script.js
```

2) A base URI can be defined in a new command-line parameter. This is used to define the scheme, host and port number to be used for all requests. This overrides all other behaviour. This feature allows for simplification of input files, removing the details and allowing for reuse of the files for different hosts or protocols.

There are some rough edges that may need to be worked on but I am keen to get this infront of you for review.

Please let me know what you think.