### PR TITLE
h2load timeout options

### DIFF
--- a/doc/h2load.h2r
+++ b/doc/h2load.h2r
@@ -19,6 +19,9 @@ requests
     This is the subset of the number reported in ``failed`` and most
     likely the network level failures or stream was reset by
     RST_STREAM.
+  timeout
+    The number of requests whose connection timed out before they 
+    were completed.
 
 status codes
   The number of status code h2load received.

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -74,8 +74,9 @@ namespace h2load {
 Config::Config()
     : data_length(-1), addrs(nullptr), nreqs(1), nclients(1), nthreads(1),
       max_concurrent_streams(-1), window_bits(30), connection_window_bits(30),
-      rate(0), nconns(0), no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0),
-      default_port(0), verbose(false) {}
+      rate(0), nconns(0), conn_active_timeout(0), conn_inactivity_timeout(0),
+      no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0), default_port(0), 
+      verbose(false) {}
 
 Config::~Config() {
   freeaddrinfo(addrs);
@@ -118,14 +119,16 @@ RequestStat::RequestStat() : data_offset(0), completed(false) {}
 
 Stats::Stats(size_t req_todo)
     : req_todo(0), req_started(0), req_done(0), req_success(0),
-      req_status_success(0), req_failed(0), req_error(0), bytes_total(0),
-      bytes_head(0), bytes_body(0), status(), req_stats(req_todo) {}
+      req_status_success(0), req_failed(0), req_error(0), req_timedout(0),
+      bytes_total(0), bytes_head(0), bytes_body(0), status(), 
+      req_stats(req_todo) {}
 
 Stream::Stream() : status_success(-1) {}
 
 namespace {
 void writecb(struct ev_loop *loop, ev_io *w, int revents) {
   auto client = static_cast<Client *>(w->data);
+  client->restart_timeout();
   auto rv = client->do_write();
   if (rv == Client::ERR_CONNECT_FAIL) {
     client->disconnect();
@@ -145,6 +148,7 @@ void writecb(struct ev_loop *loop, ev_io *w, int revents) {
 namespace {
 void readcb(struct ev_loop *loop, ev_io *w, int revents) {
   auto client = static_cast<Client *>(w->data);
+  client->restart_timeout();
   if (client->do_read() != 0) {
     client->fail();
     return;
@@ -178,6 +182,22 @@ void second_timeout_w_cb(struct ev_loop *loop, ev_timer *w, int revents) {
 }
 } // namespace
 
+namespace {
+// Called when an a connection has been inactive for a set period of time 
+// or a fixed amount of time after all requests have been made on a
+// connection
+void conn_timeout_cb(EV_P_ ev_timer *w, int revents) {
+  auto client = static_cast<Client *>(w->data);
+
+  ev_timer_stop(client->worker->loop, &client->conn_inactivity_watcher);
+  ev_timer_stop(client->worker->loop, &client->conn_active_watcher);
+
+  if (util::check_socket_connected(client->fd)) {
+    client->timeout();
+  }
+}
+} // namespace
+
 Client::Client(Worker *worker, size_t req_todo)
     : worker(worker), ssl(nullptr), next_addr(config.addrs), reqidx(0),
       state(CLIENT_IDLE), first_byte_received(false), req_todo(req_todo),
@@ -187,6 +207,14 @@ Client::Client(Worker *worker, size_t req_todo)
 
   wev.data = this;
   rev.data = this;
+
+  conn_inactivity_watcher.data = this;
+  ev_init(&conn_inactivity_watcher, conn_timeout_cb);
+  conn_inactivity_watcher.repeat = worker->config->conn_inactivity_timeout;
+
+  conn_active_watcher.data = this;
+  ev_timer_init(&conn_active_watcher, conn_timeout_cb,
+                worker->config->conn_active_timeout, 0);
 }
 
 Client::~Client() { disconnect(); }
@@ -196,6 +224,10 @@ int Client::do_write() { return writefn(*this); }
 
 int Client::connect() {
   record_start_time(&worker->stats);
+
+  if (worker->config->conn_inactivity_timeout > 0) {
+    ev_timer_again(worker->loop, &conn_inactivity_watcher);
+  }
 
   while (next_addr) {
     auto addr = next_addr;
@@ -244,6 +276,18 @@ int Client::connect() {
   return 0;
 }
 
+void Client::timeout() {
+  process_timedout_streams();
+
+  disconnect();
+}
+
+void Client::restart_timeout() {
+  if (worker->config->conn_inactivity_timeout > 0) {
+    ev_timer_again(worker->loop, &conn_inactivity_watcher);
+  }
+}
+
 void Client::fail() {
   process_abandoned_streams();
 
@@ -251,6 +295,9 @@ void Client::fail() {
 }
 
 void Client::disconnect() {
+  ev_timer_stop(worker->loop, &conn_inactivity_watcher);
+  ev_timer_stop(worker->loop, &conn_active_watcher);
+
   streams.clear();
   session.reset();
   state = CLIENT_IDLE;
@@ -274,6 +321,25 @@ void Client::submit_request() {
   auto req_stat = &worker->stats.req_stats[worker->stats.req_started++];
   session->submit_request(req_stat);
   ++req_started;
+
+  // if an active timeout is set and this is the last request to be submitted
+  // on this connection, start the active timeout.
+  if (worker->config->conn_active_timeout > 0 && req_started >= req_todo) {
+    ev_timer_start(worker->loop, &conn_active_watcher);
+  }
+}
+
+void Client::process_timedout_streams() {
+  for (auto &req_stat : worker->stats.req_stats) {
+    if (!req_stat.completed) {
+      req_stat.stream_close_time = std::chrono::steady_clock::now();
+    }
+  }
+
+  auto req_timed_out = req_todo - req_done;
+  worker->stats.req_timedout += req_timed_out;
+
+  process_abandoned_streams();
 }
 
 void Client::process_abandoned_streams() {
@@ -1078,7 +1144,8 @@ Options:
               Available protocol: )";
 #endif // !HAVE_SPDYLAY
   out << NGHTTP2_CLEARTEXT_PROTO_VERSION_ID << R"(
-              Default: )" << NGHTTP2_CLEARTEXT_PROTO_VERSION_ID << R"(
+              Default: )" 
+      << NGHTTP2_CLEARTEXT_PROTO_VERSION_ID << R"(
   -d, --data=<PATH>
               Post FILE to  server.  The request method  is changed to
               POST.
@@ -1100,10 +1167,26 @@ Options:
               to make  the -n  requests specified.  The  default value
               for this option is 0.  The  -n option is not required if
               the -C option is being used.
+  -T, --connection-active-timeout=<N>
+              Specifies  the  maximum  time  that h2load is willing to 
+              keep a  connection  open, regardless of  the activity on 
+              said  connection.  <N> must  be   a   positive  integer, 
+              specifying  the  number  of  seconds  to  wait.  When no 
+              timeout value is set (either active or inactive), h2load 
+              will keep a connection open indefinitely, waiting for  a 
+              response.
+  -N, --connection-inactivity-timeout=<N>
+              Specifies the amount of time  that  h2load is willing to 
+              wait to see activity on a given connection. <N> must  be  
+              a positive integer, specifying the number of seconds  to 
+              wait.  When  no  timeout  value is set (either active or 
+              inactive),  h2load   will   keep   a   connection   open 
+              indefinitely, waiting for a response.
   -v, --verbose
               Output debug information.
   --version   Display version information and exit.
-  -h, --help  Display this help and exit.)" << std::endl;
+  -h, --help  Display this help and exit.)" 
+      << std::endl;
 }
 } // namespace
 
@@ -1137,10 +1220,12 @@ int main(int argc, char **argv) {
         {"ciphers", required_argument, &flag, 2},
         {"rate", required_argument, nullptr, 'r'},
         {"num-conns", required_argument, nullptr, 'C'},
+        {"connection-active-timeout", required_argument, nullptr, 'T'},
+        {"connection-inactivity-timeout", required_argument, nullptr, 'N'},
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
-    auto c = getopt_long(argc, argv, "hvW:c:d:m:n:p:t:w:H:i:r:C:", long_options,
-                         &option_index);
+    auto c = getopt_long(argc, argv, "hvW:c:d:m:n:p:t:w:H:i:r:C:T:N:", 
+                         long_options, &option_index);
     if (c == -1) {
       break;
     }
@@ -1247,6 +1332,22 @@ int main(int argc, char **argv) {
       config.nconns = strtoul(optarg, nullptr, 10);
       if (config.nconns == 0) {
         std::cerr << "-C: the total number of connections made "
+                  << "must be positive." << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      break;
+    case 'T':
+      config.conn_active_timeout = strtoul(optarg, nullptr, 10);
+      if (config.conn_active_timeout <= 0) {
+        std::cerr << "-T: the conn_active_timeout wait time "
+                  << "must be positive." << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      break;
+    case 'N':
+      config.conn_inactivity_timeout = strtoul(optarg, nullptr, 10);
+      if (config.conn_inactivity_timeout <= 0) {
+        std::cerr << "-N: the conn_inactivity_timeout wait time "
                   << "must be positive." << std::endl;
         exit(EXIT_FAILURE);
       }
@@ -1656,6 +1757,7 @@ int main(int argc, char **argv) {
     stats.req_todo += s.req_todo;
     stats.req_started += s.req_started;
     stats.req_done += s.req_done;
+    stats.req_timedout += s.req_timedout;
     stats.req_success += s.req_success;
     stats.req_status_success += s.req_status_success;
     stats.req_failed += s.req_failed;
@@ -1697,7 +1799,8 @@ finished in )" << util::format_duration(duration) << ", " << rps << " req/s, "
 requests: )" << stats.req_todo << " total, " << stats.req_started
             << " started, " << stats.req_done << " done, "
             << stats.req_status_success << " succeeded, " << stats.req_failed
-            << " failed, " << stats.req_error << R"( errored
+            << " failed, " << stats.req_error << " errored, " 
+            << stats.req_timedout << R"( timeout
 status codes: )" << stats.status[2] << " 2xx, " << stats.status[3] << " 3xx, "
             << stats.status[4] << " 4xx, " << stats.status[5] << R"( 5xx
 traffic: )" << stats.bytes_total << " bytes total, " << stats.bytes_head


### PR DESCRIPTION
Continuing #322. 

It would be nice if h2load could timeout certain connections and close them, rather than waiting indefinitely until they close by themselves. In order to do this, I would like to add two new options to h2load: one to specify a way to timeout a connection after a fixed period of time, and another to timeout a connection if there has been no activity on said connection for a fixed period of time. 

Option 1 -- active timeout
========
This new option for h2load will ensure that all connections have a max time they are allowed to be open.

-T, --connection-active-timeout=N
Specifies the maximum time that h2load is willing to keep a connection open, regardless of the activity on said connection. N must be a positive integer, specifying the number of seconds to wait. When no timeout value is set (either active or inactive), h2load will keep a connection open indefinitely, waiting for a response.
 
After the last request is sent on any given connection, the connection will wait --connection-active-timeout seconds before it is closed by h2load. Any timed-out requests will be added to the timeout count.

Option 2 -- inactivity timeout
=======
This new option for h2load allows connections to be timed out after a certain amount of inactivity.

-N, --connection-inactivity-timeout=<N>
Specifies the amount of time N that h2load is willing to wait to see activity on a given connection. N must be a positive integer, specifying the number of seconds to wait. When no timeout value is set (either active or inactive), h2load will keep a connection open indefinitely, waiting for a response.
 
If a connection sees no activity within --connection-inactivity-timeout seconds, it will be closed by h2load. Any timed-out requests will be added to the timeout count.

Usage
=======
```
h2load -r2 -C20 -N2 -T5 https://www.google.com
starting benchmark...
spawning thread #0: 20 concurrent clients, 20 total requests
Protocol: TLSv1.2
Cipher: ECDHE-RSA-AES128-GCM-SHA256

finished in 10.11s, 1.87921 req/s, 98.44KB/s
requests: 20 total, 20 started, 20 done, 19 succeeded, 1 failed, 1 errored
status codes: 19 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 1019146 bytes total, 10319 bytes headers, 1006669 bytes data
                     min         max         mean         sd        +/- sd
time for request:    51.98ms     70.07ms     58.85ms      4.83ms    68.42%
time for connect:    39.40ms     66.75ms     45.64ms      6.72ms    85.00%
time to 1st byte:    39.53ms     66.85ms     45.74ms      6.73ms    85.00%
requests timed out:1
```
In this example, one request is timed out due to inactivity. 

The timed-out requests will affect all stats that they are able to completely finish--meaning their time for connect, status codes, etc. will be factored into the stats, but time for request will not as the request did not complete fully before it was timed out. 

Additionally, if the -T or -N option is used, the number of requests timed out will be printed out on a separate line. The number of requests timed out is equal to the number of requests actively timed out or timed out due to inactivity during the test. Timed out requests will count as both failed and errored. 
