### PR TITLE
start nghttpx with --daemon

### DIFF
--- a/contrib/nghttpx-init.in
+++ b/contrib/nghttpx-init.in
@@ -20,7 +20,7 @@ NAME=nghttpx
 # Depending on the configuration, binary may be located under @sbindir@
 DAEMON=@bindir@/$NAME
 PIDFILE=/var/run/$NAME.pid
-DAEMON_ARGS="--conf /etc/nghttpx/nghttpx.conf --pid-file=$PIDFILE"
+DAEMON_ARGS="--conf /etc/nghttpx/nghttpx.conf --pid-file=$PIDFILE --daemon"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed


### PR DESCRIPTION
This is a short fix for the bug in sysv service (see https://bugs.debian.org/798598).
nghttpx should be started with --daemon

Cheers,
Tomasz