### PR TITLE
Fix daemon upgrade when running under systemd

### DIFF
--- a/contrib/nghttpx.service.in
+++ b/contrib/nghttpx.service.in
@@ -3,8 +3,8 @@ Description=HTTP/2 experimental proxy
 After=network.target
 
 [Service]
-Type=simple
-ExecStart=@bindir@/nghttpx --errorlog-syslog
+Type=forking
+ExecStart=@bindir@/nghttpx --conf=/etc/nghttpx/nghttpx.conf --pid-file=/run/nghttpx.pid --daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Systemd assumes that service of type simple is stopped when the main
process exits. This causes systemd to kill all nghttpx processes when
doing a process upgrade (via USR2/QUIT signals). Change the service
type to forking which behaves correctly on upgrade.