### PR TITLE
Added support for RFC 7413 (TCP Fast Open) on nghttpx proxy for listening connections.

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -102,6 +102,7 @@ OPTIONS = [
     "response-phase-file",
     "accept-proxy-protocol",
     "conf",
+    "fastopen",
 ]
 
 LOGVARS = [

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -649,6 +649,7 @@ enum {
   SHRPX_OPTID_DH_PARAM_FILE,
   SHRPX_OPTID_ERRORLOG_FILE,
   SHRPX_OPTID_ERRORLOG_SYSLOG,
+  SHRPX_OPTID_FASTOPEN,
   SHRPX_OPTID_FETCH_OCSP_RESPONSE_FILE,
   SHRPX_OPTID_FRONTEND,
   SHRPX_OPTID_FRONTEND_FRAME_DEBUG,
@@ -812,6 +813,11 @@ int option_lookup_token(const char *name, size_t namelen) {
       }
       if (util::strieq_l("pid-fil", name, 7)) {
         return SHRPX_OPTID_PID_FILE;
+      }
+      break;
+    case 'n':
+      if (util::strieq_l("fastope", name, 7)) {
+        return SHRPX_OPTID_FASTOPEN;
       }
       break;
     case 't':
@@ -1444,6 +1450,21 @@ int parse_config(const char *opt, const char *optarg,
     mod_config()->errorlog_syslog = util::strieq(optarg, "yes");
 
     return 0;
+  case SHRPX_OPTID_FASTOPEN: {
+    int n;
+    if (parse_int(&n, opt, optarg) != 0) {
+      return -1;
+    }
+
+    if (n < 0) {
+      LOG(ERROR) << opt << ": " << optarg << " is not allowed";
+      return -1;
+    }
+
+    mod_config()->fastopen = n;
+
+    return 0;
+  }  
   case SHRPX_OPTID_BACKEND_KEEP_ALIVE_TIMEOUT:
     return parse_duration(&mod_config()->downstream_idle_read_timeout, opt,
                           optarg);

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -187,6 +187,7 @@ constexpr char SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_MAX_FAIL[] =
 constexpr char SHRPX_OPT_REQUEST_PHASE_FILE[] = "request-phase-file";
 constexpr char SHRPX_OPT_RESPONSE_PHASE_FILE[] = "response-phase-file";
 constexpr char SHRPX_OPT_ACCEPT_PROXY_PROTOCOL[] = "accept-proxy-protocol";
+constexpr char SHRPX_OPT_FASTOPEN[] = "fastopen";
 
 union sockaddr_union {
   sockaddr_storage storage;
@@ -377,6 +378,7 @@ struct Config {
   int syslog_facility;
   int backlog;
   int argc;
+  int fastopen;
   uid_t uid;
   gid_t gid;
   pid_t pid;


### PR DESCRIPTION
This patch enables setting fastopen on listening tcp socket to allow faster connection setup. 
--fastopen option was added to binary which will take limit of number of requests with handshake for security.

More description https://tools.ietf.org/html/rfc7413