### PR TITLE
h2load: Add option for user-definable rate period

### DIFF
--- a/src/h2load.h
+++ b/src/h2load.h
@@ -81,6 +81,7 @@ struct Config {
   size_t connection_window_bits;
   // rate at which connections should be made
   size_t rate;
+  ev_tstamp rate_period;
   // number of connections made
   size_t nconns;
   // amount of time to wait for activity on a given connection


### PR DESCRIPTION
This PR relates to #358. The changes take a different approach from my initial suggestion in the issue, its a quick prototype rather than the finished goods but I've done some testing and looks ok so far.

A new option `--rate-period` is added allowing a user to define a period between client creation greater than 1 second (the default is still 1 second so existing functionality is unaffected). This allows a user to define that a total `C` clients should be created at a rate of `rate / rate-period`. 

The effect of combining these parameters may not be immediately obvious to a user, therefore some more information is printed at startup. Most importantly clients may not be concurrent when using rate mode, so we remove that terminology.

Note that this PR does not address the `connection rate must be greater than or equal to the number of threads` constraint. Nor does it address smooth vs. stepped creation.

Lets look at an example, the below command will create 6 clients over 2 threads at a rate of 2 clients per 30 seconds:

```
h2load --npn-list=http/1.1 -phttp/1.1 -Bhttp://192.168.56.101:8080 --threads=2 --rate=2 --rate-period=30 --num-conn=6 /index.html 

starting benchmark...
spawning thread #0: 3 total client(s). Up to 2 client(s) will be created every 30 seconds. 3 total requests
spawning thread #1: 3 total client(s). Up to 2 client(s) will be created every 30 seconds. 3 total requests
Application protocol: http/1.1

finished in 113.85s, x.x req/s, y.yKB/s
requests: 6 total, 6 started, 6 done, 6 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 6 2xx, 0 3xx, 0 4xx, 0 5xx
```

First client on each thread is made as soon as possible, then after 30 seconds two clients are created in each thread. Once all responses complete, h2load finishes.