### PR TITLE
h2load: do not overwrite protocol value

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -594,7 +594,6 @@ int Client::connection_made() {
     }
 #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
-    next_proto = nullptr;
     if (next_proto) {
       if (util::check_h2_is_selected(next_proto, next_proto_len)) {
         session = make_unique<Http2Session>(this);


### PR DESCRIPTION
Fixes bug introduced in b051dde as part of #411 