### PR TITLE
added apparmor profile

### DIFF
--- a/contrib/usr.sbin.nghttpx
+++ b/contrib/usr.sbin.nghttpx
@@ -1,0 +1,16 @@
+#include <tunables/global>
+
+/usr/sbin/nghttpx {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+
+  capability setgid,
+  capability setuid,
+
+  /usr/sbin/nghttpx rmix,      # allow to run itself
+  /etc/nghttpx/nghttpx.conf r, # allow to read the config file
+  /etc/ssl/** r,               # give access to ssl keys
+
+  /{,var/}run/nghttpx.pid lw,  # allow to store a pid file
+}


### PR DESCRIPTION
Hi,
I propose to add an apparmor profile for nghttpx. This is my first take, it seems to work, although it assumes that the SSL keys are stored under /etc/ssl/. I plan to add this in the Debian package, but before that I wanted to discuss this with you.

Let me know what you think!

Cheers,
Tomasz