### PR TITLE
h2load goes into infinite loop when timing script file starts with 0.…

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -742,10 +742,14 @@ int Client::connection_made() {
         break;
       }
       duration = config.timings[reqidx];
+      if(reqidx == 0) //if reqidx wraps around back to 0, we uses up all lines and should break
+        break;
     }
 
-    request_timeout_watcher.repeat = duration;
-    ev_timer_again(worker->loop, &request_timeout_watcher);
+    if (duration >= 1e-9) { //double check since we may have break due to reqidx wraps around back to 0
+      request_timeout_watcher.repeat = duration;
+      ev_timer_again(worker->loop, &request_timeout_watcher);
+    }
   }
   signal_write();
 


### PR DESCRIPTION
…0 in first line

This is a simple fix for that.
And here is my sample timing script and I run it as "h2load -t1 -r2 -c10 --timing-script-file=./script.txt"

0.0	https://screen.yahoo.com/
0.0	/__rapid-worker-1.1.js
