### PR TITLE
libnghttp2_asio: Added io_service accessors

### DIFF
--- a/src/asio_io_service_pool.cc
+++ b/src/asio_io_service_pool.cc
@@ -92,6 +92,10 @@ boost::asio::io_service &io_service_pool::get_io_service() {
   return io_service;
 }
 
+std::vector<std::shared_ptr<boost::asio::io_service>> &io_service_pool::get_io_services() {
+  return io_services_;
+}
+
 } // namespace asio_http2
 
 } // namespace nghttp2

--- a/src/asio_io_service_pool.cc
+++ b/src/asio_io_service_pool.cc
@@ -92,7 +92,7 @@ boost::asio::io_service &io_service_pool::get_io_service() {
   return io_service;
 }
 
-std::vector<std::shared_ptr<boost::asio::io_service>> &io_service_pool::get_io_services() {
+const std::vector<std::shared_ptr<boost::asio::io_service>> &io_service_pool::get_io_services() const {
   return io_services_;
 }
 

--- a/src/asio_io_service_pool.h
+++ b/src/asio_io_service_pool.h
@@ -70,6 +70,9 @@ public:
   /// Get an io_service to use.
   boost::asio::io_service &get_io_service();
 
+  /// Get access to all io_service objects.
+  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
+
 private:
   /// The pool of io_services.
   std::vector<std::shared_ptr<boost::asio::io_service>> io_services_;

--- a/src/asio_io_service_pool.h
+++ b/src/asio_io_service_pool.h
@@ -71,7 +71,7 @@ public:
   boost::asio::io_service &get_io_service();
 
   /// Get access to all io_service objects.
-  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
+  const std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services() const;
 
 private:
   /// The pool of io_services.

--- a/src/asio_server.cc
+++ b/src/asio_server.cc
@@ -169,7 +169,7 @@ void server::stop() { io_service_pool_.stop(); }
 
 void server::join() { io_service_pool_.join(); }
 
-std::vector<std::shared_ptr<boost::asio::io_service>> &server::get_io_services() {
+const std::vector<std::shared_ptr<boost::asio::io_service>> &server::get_io_services() const {
   return io_service_pool_.get_io_services();
 }
 

--- a/src/asio_server.cc
+++ b/src/asio_server.cc
@@ -169,6 +169,10 @@ void server::stop() { io_service_pool_.stop(); }
 
 void server::join() { io_service_pool_.join(); }
 
+std::vector<std::shared_ptr<boost::asio::io_service>> &server::get_io_services() {
+  return io_service_pool_.get_io_services();
+}
+
 } // namespace server
 } // namespace asio_http2
 } // namespace nghttp2

--- a/src/asio_server.h
+++ b/src/asio_server.h
@@ -74,7 +74,7 @@ public:
   void stop();
 
   /// Get access to all io_service objects.
-  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
+  const std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services() const;
 
 private:
   /// Initiate an asynchronous accept operation.

--- a/src/asio_server.h
+++ b/src/asio_server.h
@@ -73,6 +73,9 @@ public:
   void join();
   void stop();
 
+  /// Get access to all io_service objects.
+  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
+
 private:
   /// Initiate an asynchronous accept operation.
   void start_accept(tcp::acceptor &acceptor, serve_mux &mux);

--- a/src/asio_server_http2.cc
+++ b/src/asio_server_http2.cc
@@ -77,7 +77,7 @@ void http2::stop() { impl_->stop(); }
 
 void http2::join() { return impl_->join(); }
 
-std::vector<std::shared_ptr<boost::asio::io_service>> &http2::get_io_services() {
+const std::vector<std::shared_ptr<boost::asio::io_service>> &http2::get_io_services() const {
   return impl_->get_io_services();
 }
 

--- a/src/asio_server_http2.cc
+++ b/src/asio_server_http2.cc
@@ -77,6 +77,10 @@ void http2::stop() { impl_->stop(); }
 
 void http2::join() { return impl_->join(); }
 
+std::vector<std::shared_ptr<boost::asio::io_service>> &http2::get_io_services() {
+  return impl_->get_io_services();
+}
+
 } // namespace server
 
 } // namespace asio_http2

--- a/src/asio_server_http2_impl.cc
+++ b/src/asio_server_http2_impl.cc
@@ -59,6 +59,10 @@ void http2_impl::stop() { return server_->stop(); }
 
 void http2_impl::join() { return server_->join(); }
 
+std::vector<std::shared_ptr<boost::asio::io_service>> &http2_impl::get_io_services() {
+  return server_->get_io_services();
+}
+
 } // namespace server
 
 } // namespace asio_http2

--- a/src/asio_server_http2_impl.cc
+++ b/src/asio_server_http2_impl.cc
@@ -59,7 +59,7 @@ void http2_impl::stop() { return server_->stop(); }
 
 void http2_impl::join() { return server_->join(); }
 
-std::vector<std::shared_ptr<boost::asio::io_service>> &http2_impl::get_io_services() {
+const std::vector<std::shared_ptr<boost::asio::io_service>> &http2_impl::get_io_services() const {
   return server_->get_io_services();
 }
 

--- a/src/asio_server_http2_impl.h
+++ b/src/asio_server_http2_impl.h
@@ -50,6 +50,7 @@ public:
   bool handle(std::string pattern, request_cb cb);
   void stop();
   void join();
+  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
 
 private:
   std::unique_ptr<server> server_;

--- a/src/asio_server_http2_impl.h
+++ b/src/asio_server_http2_impl.h
@@ -50,7 +50,7 @@ public:
   bool handle(std::string pattern, request_cb cb);
   void stop();
   void join();
-  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
+  const std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services() const;
 
 private:
   std::unique_ptr<server> server_;

--- a/src/includes/nghttp2/asio_http2_server.h
+++ b/src/includes/nghttp2/asio_http2_server.h
@@ -202,7 +202,7 @@ public:
   void join();
 
   // Get access to the io_service objects.
-  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
+  const std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services() const;
 
 private:
   std::unique_ptr<http2_impl> impl_;

--- a/src/includes/nghttp2/asio_http2_server.h
+++ b/src/includes/nghttp2/asio_http2_server.h
@@ -201,6 +201,9 @@ public:
   // Join on http2 server and wait for it to fully stop
   void join();
 
+  // Get access to the io_service objects.
+  std::vector<std::shared_ptr<boost::asio::io_service>> &get_io_services();
+
 private:
   std::unique_ptr<http2_impl> impl_;
 };


### PR DESCRIPTION
To allow the asio wrapper to work with boost.fiber it is required
to access the underlying io_service objects.