### PR TITLE
fix typos in documents.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,7 +274,7 @@ for this 24 bytes byte string and updated API.
   ``NGHTTP2_CLIENT_MAGIC_LEN``.
 * ``NGHTTP2_BAD_PREFACE`` was renamed as ``NGHTTP2_BAD_CLIENT_MAGIC``
 
-The alreay deprecated ``NGHTTP2_CLIENT_CONNECTION_HEADER`` and
+The already deprecated ``NGHTTP2_CLIENT_CONNECTION_HEADER`` and
 ``NGHTTP2_CLIENT_CONNECTION_HEADER_LEN`` were removed.
 
 If application uses these macros, just replace old ones with new ones.

--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -3275,7 +3275,7 @@ nghttp2_submit_response(nghttp2_session *session, int32_t stream_id,
  * has already sent and if `nghttp2_submit_trailer()` is called before
  * any response HEADERS submission (usually by
  * `nghttp2_submit_response()`), the content of |nva| will be sent as
- * reponse headers, which will result in error.
+ * response headers, which will result in error.
  *
  * This function has the same effect with `nghttp2_submit_headers()`,
  * with flags = :enum:`NGHTTP2_FLAG_END_HEADERS` and both pri_spec and
@@ -3418,7 +3418,7 @@ nghttp2_submit_headers(nghttp2_session *session, uint8_t flags,
  * :enum:`NGHTTP2_ERR_INVALID_ARGUMENT`
  *     The |stream_id| is 0.
  * :enum:`NGHTTP2_ERR_STREAM_CLOSED`
- *     The stream was alreay closed; or the |stream_id| is invalid.
+ *     The stream was already closed; or the |stream_id| is invalid.
  *
  * .. note::
  *
@@ -3587,7 +3587,7 @@ NGHTTP2_EXTERN int nghttp2_submit_settings(nghttp2_session *session,
  *     The |stream_id| is 0; The |stream_id| does not designate stream
  *     that peer initiated.
  * :enum:`NGHTTP2_ERR_STREAM_CLOSED`
- *     The stream was alreay closed; or the |stream_id| is invalid.
+ *     The stream was already closed; or the |stream_id| is invalid.
  *
  * .. warning::
  *
@@ -4174,7 +4174,7 @@ typedef enum {
  * :enum:`NGHTTP2_ERR_HEADER_COMP`
  *     Inflation process has failed.
  * :enum:`NGHTTP2_ERR_BUFFER_ERROR`
- *     The heder field name or value is too large.
+ *     The header field name or value is too large.
  *
  * Example follows::
  *

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -1823,7 +1823,7 @@ static int session_prep_frame(nghttp2_session *session,
         }
 
         if (rv != 0) {
-          // If stream was alreay closed, nghttp2_session_get_stream()
+          // If stream was already closed, nghttp2_session_get_stream()
           // returns NULL, but item is still attached to the stream.
           // Search stream including closed again.
           stream = nghttp2_session_get_stream_raw(session, frame->hd.stream_id);
@@ -1975,7 +1975,7 @@ static int session_prep_frame(nghttp2_session *session,
 
     rv = nghttp2_session_predicate_data_send(session, stream);
     if (rv != 0) {
-      // If stream was alreay closed, nghttp2_session_get_stream()
+      // If stream was already closed, nghttp2_session_get_stream()
       // returns NULL, but item is still attached to the stream.
       // Search stream including closed again.
       stream = nghttp2_session_get_stream_raw(session, frame->hd.stream_id);


### PR DESCRIPTION
easy fix.

- heder -> header
- alreay -> already
- reponse -> response