### PR TITLE
Don't check for dlopen/libdl on *BSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -268,9 +268,16 @@ if test "x${have_zlib}" = "xno"; then
 fi
 
 # dl: openssl requires libdl when it is statically linked.
-save_LIBS=$LIBS
-AC_SEARCH_LIBS([dlopen], [dl], [APPLDFLAGS="-ldl $APPLDFLAGS"], [], [])
-LIBS=$save_LIBS
+case "${host_os}" in
+  *bsd*)
+    # dlopen is in libc on *BSD
+    ;;
+  *)
+    save_LIBS=$LIBS
+    AC_SEARCH_LIBS([dlopen], [dl], [APPLDFLAGS="-ldl $APPLDFLAGS"], [], [])
+    LIBS=$save_LIBS
+    ;;
+esac
 
 # cunit
 PKG_CHECK_MODULES([CUNIT], [cunit >= 2.1], [have_cunit=yes], [have_cunit=no])


### PR DESCRIPTION
This makes linking fail on -ldl as there is no libdl on in /usr/lib or /usr/local/lib on *BSD
Tested (and part of the proposed nghttp2 1.7.0) on [https://reviews.freebsd.org/D5218|FreeBSD]