### PR TITLE
Document compiling apps and include h2load in configure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,9 @@ To build the documentation, you need to install:
 
 * sphinx (http://sphinx-doc.org/)
 
-To build and run the application programs (``nghttp``, ``nghttpd`` and
-``nghttpx``) in the ``src`` directory, the following packages are
-required:
+To build and run the application programs (``nghttp``, ``nghttpd``,
+``nghttpx`` and ``h2load``) in the ``src`` directory, the following packages
+are required:
 
 * OpenSSL >= 1.0.1
 * libev >= 4.15
@@ -159,6 +159,12 @@ To compile the source code, gcc >= 4.8.3 or clang >= 3.4 is required.
    disable multi-threading in nghttpd, nghttpx and h2load to prevent
    them from crashing. A patch is welcome to make multi threading work
    on Mac OS X platform.
+
+.. note::
+
+   To compile the associated applications (nghttp, nghttpd, nghttpx and
+   h2load), you must use the ``--enable-app`` configure option and ensure
+   that the specified requirements above are met.
 
 Notes for building on Windows (Mingw/Cygwin)
 --------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,7 @@ AC_ARG_ENABLE([threads],
 
 AC_ARG_ENABLE([app],
     [AS_HELP_STRING([--enable-app],
-                    [Build applications (nghttp, nghttpd and nghttpx) [default=check]])],
+                    [Build applications (nghttp, nghttpd, nghttpx and h2load) [default=check]])],
     [request_app=$enableval], [request_app=check])
 
 AC_ARG_ENABLE([hpack-tools],

--- a/doc/sources/h2load-howto.rst
+++ b/doc/sources/h2load-howto.rst
@@ -6,6 +6,15 @@ spdylay (http://tatsuhiro-t.github.io/spdylay/) library, it also
 supports SPDY protocol.  It supports SSL/TLS and clear text for all
 supported protocols.
 
+Compiling from source
+---------------------
+
+``h2load`` is compiled alongside ``nghttp2`` and requires that the
+``--enable-apps`` flag is passed to ``./configure`` and `required dependencies
+<https://github.com/tatsuhiro-t/nghttp2#requirements>`_ are available during
+compilation. For details on compiling, see `nghttp2: Building from Git
+<https://github.com/tatsuhiro-t/nghttp2#building-from-git>`_.
+
 Basic Usage
 -----------
 


### PR DESCRIPTION
Finding the info on how to compile h2load was surprisingly hard -- it's got a documentation page on how to use it (https://nghttp2.org/documentation/h2load-howto.html) but compilation isn't mentioned and there's no mention in the configure file or readme.

This PR adds those details, highlighting that the ``--enable-app`` flag is what needs to be passed to `./configure` to build.