### PR TITLE
Improve support for out-of-tree builds, assorted build fixes

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -145,15 +145,18 @@ APIDOCS= \
 	nghttp2_submit_window_update.rst \
 	nghttp2_version.rst
 
-EXTRA_DIST = \
-	mkapiref.py \
+RST_FILES = \
 	README.rst \
 	programmers-guide.rst \
-	$(APIDOCS) \
 	nghttp.1.rst \
 	nghttpd.1.rst \
 	nghttpx.1.rst \
-	h2load.1.rst \
+	h2load.1.rst
+
+EXTRA_DIST = \
+	mkapiref.py \
+	$(RST_FILES) \
+	$(APIDOCS) \
 	sources/index.rst \
 	sources/tutorial-client.rst \
 	sources/tutorial-server.rst \
@@ -227,7 +230,8 @@ help:
 
 apiref.rst: \
 	$(top_builddir)/lib/includes/nghttp2/nghttp2ver.h \
-	$(top_builddir)/lib/includes/nghttp2/nghttp2.h
+	$(top_srcdir)/lib/includes/nghttp2/nghttp2.h
+	for i in $(RST_FILES); do [ -e $(builddir)/$$i ] || cp $(srcdir)/$$i $(builddir); done
 	$(PYTHON) $(top_srcdir)/doc/mkapiref.py \
 	apiref.rst macros.rst enums.rst types.rst . $^
 

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -41,7 +41,7 @@ import sys, os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-sys.path.append(os.path.abspath('_exts'))
+sys.path.append(os.path.abspath('@top_srcdir@/doc/_exts'))
 
 # -- General configuration -----------------------------------------------------
 

--- a/examples/client.c
+++ b/examples/client.c
@@ -289,8 +289,6 @@ static int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
   return 0;
 }
 
-#define MAX_OUTLEN 4096
-
 /*
  * The implementation of nghttp2_on_data_chunk_recv_callback type. We
  * use this function to print the received response body.

--- a/examples/tiny-nghttpd.c
+++ b/examples/tiny-nghttpd.c
@@ -295,7 +295,7 @@ static size_t http_date(char *buf, time_t t) {
 static char date[29];
 static size_t datelen;
 
-static void update_date() { datelen = http_date(date, time(NULL)); }
+static void update_date(void) { datelen = http_date(date, time(NULL)); }
 
 static size_t utos(char *buf, size_t len, uint64_t n) {
   size_t nwrite = 0;

--- a/integration-tests/Makefile.am
+++ b/integration-tests/Makefile.am
@@ -21,11 +21,14 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-EXTRA_DIST = \
+GO_FILES = \
 	nghttpx_http1_test.go \
 	nghttpx_http2_test.go \
 	nghttpx_spdy_test.go \
-	server_tester.go \
+	server_tester.go
+
+EXTRA_DIST = \
+	$(GO_FILES) \
 	server.key \
 	server.crt \
 	alt-server.key \
@@ -43,4 +46,5 @@ itprep-local:
 	go get -d -v golang.org/x/net/websocket
 
 it-local:
+	for i in $(GO_FILES); do [ -e $(builddir)/$$i ] || cp $(srcdir)/$$i $(builddir); done
 	sh setenv go test -v

--- a/integration-tests/config.go.in
+++ b/integration-tests/config.go.in
@@ -2,4 +2,5 @@ package nghttp2
 
 const (
 	buildDir = "@top_builddir@"
+	sourceDir = "@top_srcdir@"
 )

--- a/integration-tests/server_tester.go
+++ b/integration-tests/server_tester.go
@@ -29,7 +29,8 @@ import (
 const (
 	serverBin  = buildDir + "/src/nghttpx"
 	serverPort = 3009
-	testDir    = buildDir + "/integration-tests"
+	testDir    = sourceDir + "/integration-tests"
+	logDir	   = buildDir + "/integration-tests"
 )
 
 func pair(name, value string) hpack.HeaderField {
@@ -124,7 +125,7 @@ func newServerTesterInternal(args []string, t *testing.T, handler http.Handler, 
 	// "127.0.0.1,8080"
 	b := "-b" + strings.Replace(backendURL.Host, ":", ",", -1)
 	args = append(args, fmt.Sprintf("-f127.0.0.1,%v", serverPort), b,
-		"--errorlog-file="+testDir+"/log.txt", "-LINFO")
+		"--errorlog-file="+logDir+"/log.txt", "-LINFO")
 
 	authority := fmt.Sprintf("127.0.0.1:%v", serverPort)
 

--- a/lib/nghttp2_npn.h
+++ b/lib/nghttp2_npn.h
@@ -25,9 +25,9 @@
 #ifndef NGHTTP2_NPN_H
 #define NGHTTP2_NPN_H
 
-#ifdef HAVE_CONFIG
+#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif /* HAVE_CONFIG */
+#endif /* HAVE_CONFIG_H */
 
 #include <nghttp2/nghttp2.h>
 


### PR DESCRIPTION
Fixes building docs (`make man`, `make latex`) in an out-of-tree build and running integration tests (`make it`). The cmake series depend on this for a proper out-of-tree build.

Also includes two minor fixes (compile warnings in examples and a harmless `HAVE_CONFIG(_H)` typo).