### PR TITLE
tests: remove unused macros

### DIFF
--- a/tests/nghttp2_session_test.c
+++ b/tests/nghttp2_session_test.c
@@ -36,10 +36,6 @@
 #include "nghttp2_test_helper.h"
 #include "nghttp2_priority_spec.h"
 
-#define OB_CTRL(ITEM) nghttp2_outbound_item_get_ctrl_frame(ITEM)
-#define OB_CTRL_TYPE(ITEM) nghttp2_outbound_item_get_ctrl_frame_type(ITEM)
-#define OB_DATA(ITEM) nghttp2_outbound_item_get_data_frame(ITEM)
-
 typedef struct {
   uint8_t buf[65535];
   size_t length;


### PR DESCRIPTION
Since v0.6.2-7-g1d138ac ("Unify DATA and other frames in
nghttp2_outbound_item and save malloc()"), the macros are unused and the
builds fails on -Werror=unused-macros.