### PR TITLE
integration-tests: do not use recursive target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,5 @@ script:
   - make check
   - cd integration-tests
   - export GOPATH="$PWD/integration-tests/golang"
-  - make itprep-local
-  - make it-local
+  - make itprep
+  - make it

--- a/configure.ac
+++ b/configure.ac
@@ -40,8 +40,6 @@ AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE([subdir-objects])
 
-# AM_EXTRA_RECURSIVE_TARGETS requires automake 1.13 or higher
-m4_ifdef([AM_EXTRA_RECURSIVE_TARGETS], [AM_EXTRA_RECURSIVE_TARGETS([it itprep])])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 dnl See versioning rule:

--- a/integration-tests/Makefile.am
+++ b/integration-tests/Makefile.am
@@ -39,12 +39,12 @@ EXTRA_DIST = \
 	req-return.rb \
 	resp-return.rb
 
-itprep-local:
+itprep:
 	go get -d -v golang.org/x/net/http2
 	go get -d -v github.com/tatsuhiro-t/go-nghttp2
 	go get -d -v github.com/tatsuhiro-t/spdy
 	go get -d -v golang.org/x/net/websocket
 
-it-local:
+it:
 	for i in $(GO_FILES); do [ -e $(builddir)/$$i ] || cp $(srcdir)/$$i $(builddir); done
 	sh setenv go test -v


### PR DESCRIPTION
This is a preparation for the CMake build system which does not have an "it-local" target. After this change you cannot invoke "make it" from the root directory (when using autotools), if that is wanted additional targets could be added to the top Makefile.am. (The documented `make -C integration-tests it` command is still functional though.)
___
Older automake (travis, *cough*) do not support the
AM_EXTRA_RECURSIVE_TARGETS option, this results in invoking "it-local"
directly in the travis script which relies on an implementation detail.

Since the "it" target is only used by the integration-tests directory,
just avoid the recursive targets. The README.rst suggests to enter the
integration-tests directory anyway.